### PR TITLE
Add "one URL per line" desc to relatedLink / softwareRequirements fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,10 @@ See top-level LICENSE file for more information
                 <label for="relatedLink">Related links</label>
                 <br />
                 <textarea rows="4" cols="50"
-                    name="relatedLink" id="relatedLink"></textarea>
+                    name="relatedLink" id="relatedLink"
+                    placeholder="https://www.example.com"></textarea>
+                <span class="field-description" id="relatedLink_descr">URL(s), one URL per line</span>
+            </p>
         </fieldset>
 
         <fieldset id="fieldsetRuntime" class="leafFieldset">
@@ -206,6 +209,8 @@ See top-level LICENSE file for more information
                     placeholder=
 "https://www.python.org/downloads/release/python-3130/
 https://github.com/psf/requests"></textarea>
+                <span class="field-description" id="softwareRequirements_descr">URL(s), one URL per line</span>
+            </p>
         </fieldset>
 
         <fieldset id="fieldsetCurrentVersion" class="leafFieldset">
@@ -333,9 +338,9 @@ Bugfixes: that and this." ></textarea>
 
     </form>
     <form>
-      <input type="button" id="generateCodemetaV3" value="Generate codemeta.json v3.0" disabled
-             title="Creates a codemeta.json v3.0 file below, from the information provided above." />
-      <input type="button" id="generateCodemetaV2" value="Generate codemeta.json v2.0" disabled
+        <input type="button" id="generateCodemetaV3" value="Generate codemeta.json v3.0" disabled
+            title="Creates a codemeta.json v3.0 file below, from the information provided above." />
+        <input type="button" id="generateCodemetaV2" value="Generate codemeta.json v2.0" disabled
             title="Creates a codemeta.json v2.0 file below, from the information provided above." />
         <input type="button" id="resetForm" value="Reset form"
             title="Erases all fields." />


### PR DESCRIPTION
When user put multiple URLs in one line for Related Links, the generator will warn:

> Bug detected! The data you wrote is correct; but for some reason, it seems we generated an invalid codemeta.json.

Put a field description to guide the user.

Note that relatedLink and softwareRequirements have different behaviour:

- relatedLink will still put invalid URL (a string with multiple URLs) in the JSON
- softwareRequirements on the other hand will be an empty list instead