### PR TITLE
Allow a space to be URLs separator

### DIFF
--- a/js/codemeta_generation.js
+++ b/js/codemeta_generation.js
@@ -105,8 +105,8 @@ const splittedCodemetaFields = [
     ['programmingLanguage', ','],
     ['runtimePlatform', ','],
     ['operatingSystem', ','],
-    ['softwareRequirements', '\n', generateUri, importUri],
-    ['relatedLink', '\n'],
+    ['softwareRequirements', /[\n ]/, generateUri, importUri],
+    ['relatedLink', /[\n ]/],
 ]
 
 // Names of codemeta properties with a matching HTML field name,


### PR DESCRIPTION
Split the URLs (softwareRequirements and relatedLink) by a newline and by a space.