### PR TITLE
Add "input" event listener for Firefox compatibility

### DIFF
--- a/js/dynamic_form.js
+++ b/js/dynamic_form.js
@@ -201,6 +201,10 @@ function fieldToLower(event) {
 function initCallbacks() {
     document.querySelector('#license')
         .addEventListener('change', validateLicense);
+    document.querySelector('#license')
+        .addEventListener('keydown', validateLicense);
+    document.querySelector('#license')
+        .addEventListener('input', validateLicense);
 
     document.querySelector('#generateCodemetaV2').disabled = false;
     document.querySelector('#generateCodemetaV2')

--- a/js/fields_data.js
+++ b/js/fields_data.js
@@ -42,8 +42,8 @@ function insertLicenseElement(licenseId) {
 }
 
 function validateLicense(e) {
-    // continue only if Enter/Tab key is pressed
-    if (e.key && e.key !== "Enter" && e.keyCode !== "Tab") {
+    // Continue only if Enter/Tab key is pressed
+    if (e.type === "keydown" && e.key && e.key !== "Enter" && e.keyCode !== "Tab") {
         return;
     }
     // Note: For some reason e.keyCode is undefined when Enter/Tab key is pressed.
@@ -66,7 +66,8 @@ function validateLicense(e) {
             licenseField.value = "";
             licenseField.setCustomValidity('');
             generateCodemeta();
-        } else {
+        }
+        else {
             licenseField.value = "";
             licenseField.setCustomValidity('License already added');
         }


### PR DESCRIPTION
To confirm the selection automatically in Firefox, without the need for user to hit Enter