### PR TITLE
Make license selector behaviour consistent across browsers

### DIFF
--- a/js/dynamic_form.js
+++ b/js/dynamic_form.js
@@ -199,8 +199,20 @@ function fieldToLower(event) {
 }
 
 function initCallbacks() {
+    // To keep behaviour consistent across browsers, we listen to
+    // 'input', 'change', and 'keydown' events for the license field
+    // and handle situations in the validateLicense function.
+    // This works with Firefox, Safari, and Chrome-based browsers.
+
+    // Firefox needs 'input' to catch datalist selection with mouse click.
+    // Firefox datalist selection without Enter press does not trigger 'change'.
+    document.querySelector('#license')
+        .addEventListener('input', validateLicense);
     document.querySelector('#license')
         .addEventListener('change', validateLicense);
+    // Safari needs keydown to catch Enter press when datalist is open
+    document.querySelector('#license')
+        .addEventListener('keydown', validateLicense);
 
     document.querySelector('#generateCodemetaV2').disabled = false;
     document.querySelector('#generateCodemetaV2')


### PR DESCRIPTION
Chrome, Firefox, and Safari have small differences when it comes to behaviour of datalist. This PR makes the behaviour more predictable and more convenient for a user to select licenses:

- Can click on list and immediately confirm the selection of the license (without having to hit Enter again, as it normally be on Firefox)

- Can type license ID, in any casing, and hit Tab/Enter one time to confirm the selection of the license

Tested with Chrome, Firefox, and Safari

License field now listens to three events (Enter/Tab only available to check in keystroke events such as 'keydown').

See code comments for implementation details.